### PR TITLE
fix: cities misplaced after globe transition, performance updates

### DIFF
--- a/src/lib/components/map/Map.svelte
+++ b/src/lib/components/map/Map.svelte
@@ -122,27 +122,6 @@
     }
   });
 
-  // re-render circles on radius change
-  $effect(() => {
-    if (initialLoading) return;
-
-    if (!circlesRendered.state && projection.state) {
-      logEffect('Re-render circles');
-      // renderCircles(projection.state, g.state, circleGeoData.state);
-    }
-  })
-
-  // load circles - only when checkbox is toggled
-  $effect(() => {
-    if (initialLoading) return;
-
-    if (showCircles.state && projection.state) {
-      logEffect('Show circles');
-
-      updateCircleSize();
-    }
-  });
-
   // updates when scale changes
   $effect(() => {
     if (initialLoading) return;
@@ -177,14 +156,20 @@
     }
   });
 
-  // runs whever projection changes
+  // runs whever projection changes & circle are shown
   $effect(() => {
     if (initialLoading) return;
 
     if (projection.state) {
       logEffect('Projection change: country locations');
       updateCountryLocations();
-      updateCircleLocations();
+      
+      if (showCircles.state) {
+        requestAnimationFrame(() => {
+          updateCircleSize();
+          updateCircleLocations();
+        });
+      }
     }
   })
 

--- a/src/lib/components/map/circleFunctions.svelte.ts
+++ b/src/lib/components/map/circleFunctions.svelte.ts
@@ -128,7 +128,6 @@ export function updateCircleMetrics(): typeof circleMetrics.state {
 
 // updates the size of circles on the map whenever cityFreqs updates
 export function updateCircleSize() {
-  console.log(circlesRendered.state);
   if (radiusScale.state == null) {
     console.error("Cannot update circle size: circles are not rendered or radius scale is null!");
     return;
@@ -255,7 +254,7 @@ export function updateCircleLocations() {
       return;
     }
   }
-
+  
   const geoData = circleGeoData.state;
   circleGroup.selectAll("circle").each(function (d: any) {
     const city = d.city;
@@ -271,7 +270,7 @@ export function updateCircleLocations() {
 
     if (x !== null && y !== null) {
       // Check if the circle is within the visible bounds
-      if (!isPointVisible(projection.state, lng, lat) && projectionType.state == 'globe') {
+      if (projectionType.state == 'globe' && !isPointVisible(projection.state, lng, lat)) {
         // Hide the circle if it's out of bounds
         d3.select(this).attr("display", "none");
       } else {

--- a/src/lib/components/map/globeFunctions.ts
+++ b/src/lib/components/map/globeFunctions.ts
@@ -17,7 +17,7 @@ let onMouseMove: (e: MouseEvent) => void | null;
 
 function debouncedGlobeUpdate(
   e: MouseEvent,
-  delay: number = 50,
+  delay: number = 10,
 ) {
   if (debounceTimeout || !projection.state) {
     return;
@@ -40,14 +40,16 @@ function debouncedGlobeUpdate(
 
   projection.state.rotate(newRotate);
 
-  debounceTimeout = setTimeout(() => {
-    updateCountryLocations();
+  // debounceTimeout = setTimeout(() => {
+    requestAnimationFrame(() => {
+      updateCountryLocations();
 
-    if (showCircles.state) {
-      updateCircleLocations();
-    }
-    debounceTimeout = null;
-  }, delay);
+      if (showCircles.state) {
+        updateCircleLocations();
+      }
+      debounceTimeout = null;
+    })
+  // }, delay);
 }
 
 // registers event listeners for globe updating.

--- a/src/lib/components/map/heatmapFunctions.svelte.ts
+++ b/src/lib/components/map/heatmapFunctions.svelte.ts
@@ -78,15 +78,9 @@ export function updateCountryLocations() {
     loadCountries(projection.state);
   }
 
-  if (animationFrameId) {
-    cancelAnimationFrame(animationFrameId);
-  }
-
-  animationFrameId = requestAnimationFrame(() => {
-    const path = d3.geoPath().projection(projection.state);
-    countrySelection.attr("d", (d: any) => path(d));
-    animationFrameId = null;
-  });
+  const path = d3.geoPath().projection(projection.state);
+  countrySelection.attr("d", (d: any) => path(d));
+  animationFrameId = null;
 }
 
 export function loadCountries(projection: d3.GeoProjection, loaders: boolean = false) {

--- a/src/lib/components/toggle/Toggle.svelte
+++ b/src/lib/components/toggle/Toggle.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
+  import { onMount } from "svelte";
+
   let { checked = false, projectionType = $bindable('2d') } = $props();
   function handleChange(event: Event) {
-    checked = (event.target as HTMLInputElement).checked;
     projectionType = projectionType == '2d' ? 'globe' : '2d';
+    checked = projectionType == 'globe';
   }
+
+  onMount(() => {
+    checked = projectionType == 'globe';
+  })
 </script>
 
 <label class="toggle">


### PR DESCRIPTION
Used the `useAnimationFrame` web function to increase performance when rotating the map. This also happened to fix the issue with cities appearing in the wrong spots. Also updated the toggle switch so that state is consistent after user refresh.